### PR TITLE
feat: server refactor start

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "nodemon server/server.js",
+    "start": "nodemon --watch server --exec 'node -r esm server/server.js'",
     "build": "webpack --mode production"
   },
   "keywords": [],
@@ -31,10 +31,12 @@
     "@material-ui/core": "^4.9.7",
     "@material-ui/pickers": "^3.2.10",
     "@mdi/font": "^4.9.95",
+    "body-parser": "^1.19.0",
     "capitalize": "^2.0.2",
     "chokidar": "^3.0.0",
     "cookie-parser": "^1.4.4",
     "date-fns": "^2.11.0",
+    "esm": "^3.2.25",
     "express": "^4.16.4",
     "express-ws": "^4.0.0",
     "json-loader": "^0.5.7",

--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -1,0 +1,26 @@
+import { Router } from "express";
+import { authService } from '../services';
+import { catchAll } from '../utilities';
+
+const login = async (req, res) => {
+    if (!req.body || !req.body.username || !req.body.password) {
+        throw new TypeError('Missing params!')
+    }
+
+    const username = req.body.username;
+    const password = req.body.password;
+
+    const response = await authService.handleLogin(username, password);
+
+    res.json({ success: true, ...response});
+}
+
+// instantiate new router
+const authController = new Router();
+
+// bind routes to functions
+authController.post('/login', catchAll(login));
+
+export {
+    authController
+};

--- a/server/controllers/index.js
+++ b/server/controllers/index.js
@@ -1,0 +1,1 @@
+export { authController } from './authController.js';

--- a/server/databases/authDatabase.js
+++ b/server/databases/authDatabase.js
@@ -1,0 +1,26 @@
+import { connection } from '../utils/connection.js';
+
+const performLogin = async (username, password) => {
+    const user = await connection.collection("users").findOne({ username });
+
+    if (user === null) {
+        throw new Error("Invalid username");
+    };
+
+    if (user.password != sha1(password)) {
+        throw new Error("Invalid password");
+    };
+
+    // if we pass the above conditional, userpass as to match the sha1
+    console.log("Login Success");
+    const sessionId = uuidv1();
+
+    return {
+        user,
+        sessionId
+    };
+}
+
+export {
+    performLogin
+}

--- a/server/databases/authDatabase.js
+++ b/server/databases/authDatabase.js
@@ -11,7 +11,7 @@ const performLogin = async (username, password) => {
         throw new Error("Invalid password");
     };
 
-    // if we pass the above conditional, userpass as to match the sha1
+    // if we pass the above conditional, userpass must match the sha1
     console.log("Login Success");
     const sessionId = uuidv1();
 

--- a/server/databases/index.js
+++ b/server/databases/index.js
@@ -1,0 +1,1 @@
+export * as authDatabase from './authDatabase.js';

--- a/server/server.js
+++ b/server/server.js
@@ -23,11 +23,7 @@ const { User, catchAll, Message } = require("./utilities.js");
 const MongoDB = require('mongodb');
 const MongoClient = MongoDB.MongoClient;
 const ObjectID = MongoDB.ObjectID;
-const url = config.url;
 let dbo = undefined;
-// MongoClient.connect(url, { newUrlParser: true }, (err, client) => {
-//   dbo = client.db("liane")
-// });
 
 let sessions = []; // Cookies
 let aWss = expressWs.getWss('/'); // Web Socket
@@ -365,7 +361,7 @@ app.all("/*", (req, res, next) => {
 initMongo(
   config.url
 ).then((response) => {
-  //dbo = response;
+  dbo = response;
   const { PORT = 4000, LOCAL_ADDRESS = "0.0.0.0" } = process.env; // for hiroku
   app.listen(4000, LOCAL_ADDRESS, () => {
     console.log("Server running on port " + PORT);

--- a/server/services/authService.js
+++ b/server/services/authService.js
@@ -1,0 +1,13 @@
+import { authDatabase } from '../databases';
+
+const handleLogin = async (username, password) => {
+    const { user, sessionId } = await authDatabase.performLogin(username, password);
+
+    // Here we should be saving sessions into a database, using the sessionID returned form performLogin
+
+    return user;
+}
+
+export {
+    handleLogin,
+}

--- a/server/services/index.js
+++ b/server/services/index.js
@@ -1,0 +1,1 @@
+export * as authService from './authService';

--- a/server/utilities.js
+++ b/server/utilities.js
@@ -32,4 +32,4 @@ function catchAll(fn) {
     };
 };
 
-module.exports = { User, catchAll, Message };
+export { User, catchAll, Message };

--- a/server/utils/connection.js
+++ b/server/utils/connection.js
@@ -1,0 +1,31 @@
+import { MongoClient } from "mongodb";
+
+// Reuseable connection object that gets assinged on init
+// on initMongo is called (preferably at application start)
+// theh connection will be available whereever it's imported
+let connection = null;
+
+const initMongo = async (url) => {
+  // if connection is null, assign it to a new mongo connection
+  // else do nothing
+  if (!connection) {
+    console.log("Building new Mongo connection");
+    try {
+        const mongo = await MongoClient.connect(url, {
+        useNewUrlParser: true,
+        useUnifiedTopology: true,
+        });
+
+        connection = mongo.db("ProjectDB");
+        console.log("Connection Assigned!");
+
+    } catch(e) {
+        console.log(`Unable to connect to mongo: ${e}`)
+        return null;
+    }
+  }
+
+  return;
+};
+
+export { connection, initMongo };


### PR DESCRIPTION
I made a few changes here, including adding some packages. I've added:

- esm - an add on to the runtime compiler for node, allowing us to use nicer/newer syntax without babel
- body-parser - rather than importing multer everywhere, for basic json bodys we can just use this globally

The restructure is how we discussed, controllers/services/databases. I've moved the mongo connection to be reusable across the databases. Additionally, I've done a small refactor in the server to wait for mongo to connect before starting.

I'll make inline comment explaining more granular decisions!